### PR TITLE
Rename module variable to module_es2015. Fixes #15

### DIFF
--- a/build.js
+++ b/build.js
@@ -17,14 +17,14 @@ rollup({
   entry: 'src/vanilla-tilt.js',
   plugins: [
     nodeResolve({
-      module: true,
+      module_es2015: true,
       jsnext: true,
       main: true,
     })
   ],
   external: external
 }).then(bundle => bundle.write({
-  dest: pkg.module,
+  dest: pkg.module_es2015,
   format: 'es'
 })).catch(err => console.log(err.stack));
 
@@ -32,7 +32,7 @@ rollup({
   entry: 'src/vanilla-tilt.js',
   plugins: [
     nodeResolve({
-      module: true,
+      module_es2015: true,
       jsnext: true,
       main: true,
     }),
@@ -53,7 +53,7 @@ rollup({
   entry: 'src/vanilla-tilt.js',
   plugins: [
     nodeResolve({
-      module: true,
+      module_es2015: true,
       jsnext: true,
       main: true,
     })
@@ -78,7 +78,7 @@ rollup({
   entry: 'src/vanilla-tilt.js',
   plugins: [
     nodeResolve({
-      module: true,
+      module_es2015: true,
       jsnext: true,
       main: true
     }),

--- a/lib/README.md
+++ b/lib/README.md
@@ -59,6 +59,12 @@ You can copy and include any of the following file:
 * [dist/vanilla-tilt.babel.js](https://raw.githubusercontent.com/micku7zu/vanilla-tilt.js/master/dist/vanilla-tilt.babel.js) ~ 8.5kb
 * [dist/vanilla-tilt.babel.min.js](https://raw.githubusercontent.com/micku7zu/vanilla-tilt.js/master/dist/vanilla-tilt.babel.min.js) ~ 4.3kb
 
+Also available on npm https://www.npmjs.com/package/vanilla-tilt
+
+```
+npm install vanilla-tilt
+```
+
 ### Credits
 
 Original library: [Tilt.js](http://gijsroge.github.io/tilt.js/)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "description": "A smooth 3D tilt javascript library forked from Tilt.js",
   "main": "lib/vanilla-tilt.js",
-  "module": "lib/vanilla-tilt.es2015.js",
+  "module_es2015": "lib/vanilla-tilt.es2015.js",
   "jsnext:main": "lib/vanilla-tilt.es2015.js",
   "distrib": "dist/vanilla-tilt.js",
   "scripts": {


### PR DESCRIPTION
The variable `module` is used by Webpack over the `main` variable to get the script path. So Webpack always uses the ES5 version which can't be used in the plain old not ES5 JavaScript file.

This PR fixes this problem and issue #15.