### PR TITLE
Keep "Vanilla-tilt.js" on one line in logo

### DIFF
--- a/style.css
+++ b/style.css
@@ -75,7 +75,7 @@ h3:first-child {
     text-align: center;
 
     color: white;
-    font-size: 36px;
+    font-size: 20px;
 
     background: #0099F7; /* fallback for old browsers */
     background: -webkit-linear-gradient(135deg, #0099F7 , #F11712); /* Chrome 10-25, Safari 5.1-6 */


### PR DESCRIPTION
The 200px line-height puts "-tilt.js" below logo since it wraps the text. Prevent text wrap by decreasing font size.