### PR TITLE
don't visibly glare/scale unless hovered

### DIFF
--- a/src/vanilla-tilt.js
+++ b/src/vanilla-tilt.js
@@ -295,16 +295,23 @@ export default class VanillaTilt {
   }
 
   update() {
-    let values = this.getValues();
+    const hovered = [].slice
+        .call(this.element.parentElement.querySelectorAll(':hover'))
+        .includes(this.element),
+      values = this.getValues(),
+      scale = hovered ? this.settings.scale : 1,
+      glareOpacity = hovered
+        ? (values.percentageY * this.settings['max-glare']) / 100
+        : 0;
 
     this.element.style.transform = "perspective(" + this.settings.perspective + "px) " +
       "rotateX(" + (this.settings.axis === "x" ? 0 : values.tiltY) + "deg) " +
       "rotateY(" + (this.settings.axis === "y" ? 0 : values.tiltX) + "deg) " +
-      "scale3d(" + this.settings.scale + ", " + this.settings.scale + ", " + this.settings.scale + ")";
+      "scale3d(" + scale + ", " + scale + ", " + scale + ")";
 
     if (this.glare) {
       this.glareElement.style.transform = `rotate(${values.angle}deg) translate(-50%, -50%)`;
-      this.glareElement.style.opacity = `${values.percentageY * this.settings["max-glare"] / 100}`;
+      this.glareElement.style.opacity = `${glareOpacity}`;
     }
 
     this.element.dispatchEvent(new CustomEvent("tiltChange", {


### PR DESCRIPTION
effects like glare and scale are only meant to be active when you're actually hovering over the element, right?

that's what I would expect, and what happens during normal page browsing. however, a few deviceorientation events are randomly fired on page load (at least on chromium edge/chrome), and so the element loads scaled and glaring.

this simple check means that the element will only have these effects applied if it is currently being hovered over.