### PR TITLE
Make device-orientation readable

### DIFF
--- a/src/vanilla-tilt.js
+++ b/src/vanilla-tilt.js
@@ -103,7 +103,7 @@ export default class VanillaTilt {
     }
 
     if (this.gyroscope) {
-      window.addEventListener("deviceorientation", this.onDeviceOrientationBind);
+      window.addEventListener("device-orientation", this.onDeviceOrientationBind); /* Make device-orientation readable */
     }
   }
 


### PR DESCRIPTION
Hello micku7zu,
You have done wonderful work by creating vanilla-tilt.js. It is used by millions of developers like me. I just read your code and found that deviceorientation is not readable because it is not in the camel case and also not used any hyphen or underscore to identify it. It is a very respectful project, that's why I created a pull request for it. Please consider it. Thank you.