### PR TITLE
typos: in docs for options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ A smooth 3D tilt javascript library forked from [Tilt.js (jQuery version)](https
     speed:                  300,    // Speed of the enter/exit transition
     transition:             true,   // Set a transition on enter/exit.
     axis:                   null,   // What axis should be disabled. Can be X or Y.
-    reset:                  true    // If the tilt effect has to be reset on exit.
+    reset:                  true,   // If the tilt effect has to be reset on exit.
     easing:                 "cubic-bezier(.03,.98,.52,.99)",    // Easing on enter/exit.
-    glare:                  false   // if it should have a "glare" effect
+    glare:                  false,  // if it should have a "glare" effect
     "max-glare":            1,      // the maximum "glare" opacity (1 = 100%, 0.5 = 50%)
     "glare-prerender":      false,  // false = VanillaTilt creates the glare elements for you, otherwise
-                               // you need to add .js-tilt-glare>.js-tilt-glare-inner by yourself
-    "mouse-event-element":  null    // css-selector or link to an HTML-element that will be listening to mouse events
-    gyroscope:              true    // Boolean to enable/disable device orientation detection,
-    gyroscopeMinAngleX:     -45     // This is the bottom limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the left border of the element;
-    gyroscopeMaxAngleX:     45      // This is the top limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the right border of the element;
-    gyroscopeMinAngleY:     -45     // This is the bottom limit of the device angle on Y axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the top border of the element;
+                                    // you need to add .js-tilt-glare>.js-tilt-glare-inner by yourself
+    "mouse-event-element":  null,   // css-selector or link to an HTML-element that will be listening to mouse events
+    gyroscope:              true,   // Boolean to enable/disable device orientation detection,
+    gyroscopeMinAngleX:     -45,    // This is the bottom limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the left border of the element;
+    gyroscopeMaxAngleX:     45,     // This is the top limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the right border of the element;
+    gyroscopeMinAngleY:     -45,    // This is the bottom limit of the device angle on Y axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the top border of the element;
     gyroscopeMaxAngleY:     45      // This is the top limit of the device angle on Y axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the bottom border of the element;
 
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A smooth 3D tilt javascript library forked from [Tilt.js (jQuery version)](https
     "max-glare":            1,      // the maximum "glare" opacity (1 = 100%, 0.5 = 50%)
     "glare-prerender":      false,  // false = VanillaTilt creates the glare elements for you, otherwise
                                // you need to add .js-tilt-glare>.js-tilt-glare-inner by yourself
-    "mouse-event-element":  null    // css-selector or link to HTML-element what will be listen mouse events 
+    "mouse-event-element":  null    // css-selector or link to an HTML-element that will be listening to mouse events
     gyroscope:              true    // Boolean to enable/disable device orientation detection,
     gyroscopeMinAngleX:     -45     // This is the bottom limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the left border of the element;
     gyroscopeMaxAngleX:     45      // This is the top limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the right border of the element;

--- a/index.html
+++ b/index.html
@@ -145,19 +145,19 @@
     speed:                  300,    // Speed of the enter/exit transition
     transition:             true,   // Set a transition on enter/exit.
     axis:                   null,   // What axis should be disabled. Can be X or Y.
-    reset:                  true,    // If the tilt effect has to be reset on exit.
+    reset:                  true,   // If the tilt effect has to be reset on exit.
     easing:                 "cubic-bezier(.03,.98,.52,.99)",    // Easing on enter/exit.
-    glare:                  false,   // if it should have a "glare" effect
+    glare:                  false,  // if it should have a "glare" effect
     "max-glare":            1,      // the maximum "glare" opacity (1 = 100%, 0.5 = 50%)
     "glare-prerender":      false,  // false = VanillaTilt creates the glare elements for you, otherwise
                                     // you need to add .js-tilt-glare>.js-tilt-glare-inner by yourself
-    "mouse-event-element":  null,    // css-selector or link to HTML-element what will be listen mouse events
+    "mouse-event-element":  null,   // css-selector or link to HTML-element what will be listen mouse events
                                     // you need to add .js-tilt-glare>.js-tilt-glare-inner by yourself
-    gyroscope:              true,    // Boolean to enable/disable device orientation detection,
-    gyroscopeMinAngleX:     -45,     // This is the bottom limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the left border of the element;
-    gyroscopeMaxAngleX:     45,      // This is the top limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the right border of the element;
-    gyroscopeMinAngleY:     -45,     // This is the bottom limit of the device angle on Y axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the top border of the element;
-    gyroscopeMaxAngleY:     45,      // This is the top limit of the device angle on Y axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the bottom border of the element;
+    gyroscope:              true,   // Boolean to enable/disable device orientation detection,
+    gyroscopeMinAngleX:     -45,    // This is the bottom limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the left border of the element;
+    gyroscopeMaxAngleX:     45,     // This is the top limit of the device angle on X axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the right border of the element;
+    gyroscopeMinAngleY:     -45,    // This is the bottom limit of the device angle on Y axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the top border of the element;
+    gyroscopeMaxAngleY:     45,     // This is the top limit of the device angle on Y axis, meaning that a device rotated at this angle would tilt the element as if the mouse was on the bottom border of the element;
 }</code></pre>
 
             <h4>JS Way</h4>

--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@ document.querySelector("#enable-button").addEventListener("click", function () {
         <div class="box" id="box-event"></div>
         <div class="info">
             <h3>Tilt change event</h3>
-            <p>The tilt change event wil output the x,y & percentages of tilting.</p>
+            <p>The tilt change event will output the x,y & percentages of tilting.</p>
             <pre><code class="language-javascript">let eventBox = document.querySelector("#box-event");
 let outputContainer = document.querySelector(".output");
 VanillaTilt.init(eventBox);


### PR DESCRIPTION
missing commas and misaligned comments in docs for options object