### PR TITLE
Feature: "reset to start"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you want to use this library in IE, you need to include a CustomEvent polyfil
     transition:             true,   // Set a transition on enter/exit.
     axis:                   null,   // What axis should be enabled. Can be "x" or "y".
     reset:                  true,   // If the tilt effect has to be reset on exit.
+    "reset-to-start":       false,  // Whether the exit reset will go to [0,0] (default) or [startX, startY]
     easing:                 "cubic-bezier(.03,.98,.52,.99)",    // Easing on enter/exit.
     glare:                  false,  // if it should have a "glare" effect
     "max-glare":            1,      // the maximum "glare" opacity (1 = 100%, 0.5 = 50%)

--- a/src/vanilla-tilt.js
+++ b/src/vanilla-tilt.js
@@ -35,6 +35,7 @@ export default class VanillaTilt {
     this.settings = this.extendSettings(settings);
 
     this.reverse = this.settings.reverse ? -1 : 1;
+    this.resetToStart = VanillaTilt.isSettingTrue(this.settings["reset-to-start"]);
     this.glare = VanillaTilt.isSettingTrue(this.settings.glare);
     this.glarePrerender = VanillaTilt.isSettingTrue(this.settings["glare-prerender"]);
     this.fullPageListening = VanillaTilt.isSettingTrue(this.settings["full-page-listening"]);
@@ -53,7 +54,11 @@ export default class VanillaTilt {
 
     this.addEventListeners();
     this.reset();
-    this.updateInitialPosition();
+
+    if(this.resetToStart === false){
+      this.settings.startX = 0;
+      this.settings.startY = 0;
+    }
   }
 
   static isSettingTrue(setting) {
@@ -210,33 +215,6 @@ export default class VanillaTilt {
   }
 
   reset() {
-    this.event = {
-      clientX: this.left + this.width / 2,
-      clientY: this.top + this.height / 2
-    };
-
-    if (this.element && this.element.style) {
-      this.element.style.transform = `perspective(${this.settings.perspective}px) ` +
-        `rotateX(0deg) ` +
-        `rotateY(0deg) ` +
-        `scale3d(1, 1, 1)`;
-    }
-
-    this.resetGlare();
-  }
-
-  resetGlare() {
-    if (this.glare) {
-      this.glareElement.style.transform = "rotate(180deg) translate(-50%, -50%)";
-      this.glareElement.style.opacity = "0";
-    }
-  }
-
-  updateInitialPosition() {
-    if (this.settings.startX === 0 && this.settings.startY === 0) {
-      return;
-    }
-
     this.onMouseEnter();
 
     if (this.fullPageListening) {
@@ -257,6 +235,13 @@ export default class VanillaTilt {
     this.update();
     this.settings.scale = backupScale;
     this.resetGlare();
+  }
+
+  resetGlare() {
+    if (this.glare) {
+      this.glareElement.style.transform = "rotate(180deg) translate(-50%, -50%)";
+      this.glareElement.style.opacity = "0";
+    }
   }
 
   getValues() {
@@ -423,6 +408,7 @@ export default class VanillaTilt {
    * @param {boolean} settings.full-page-listening - If true, parallax effect will listen to mouse move events on the whole document, not only the selected element
    * @param {string|object} settings.mouse-event-element - String selector or link to HTML-element what will be listen mouse events
    * @param {boolean} settings.reset - false = If the tilt effect has to be reset on exit
+   * @param {boolean} settings.reset-to-start - true = On reset event (mouse leave) will return to initial start angle (startX, startY)
    * @param {gyroscope} settings.gyroscope - Enable tilting by deviceorientation events
    * @param {gyroscopeSensitivity} settings.gyroscopeSensitivity - Between 0 and 1 - The angle at which max tilt position is reached. 1 = 90deg, 0.5 = 45deg, etc..
    * @param {gyroscopeSamples} settings.gyroscopeSamples - How many gyroscope moves to decide the starting position.
@@ -445,6 +431,7 @@ export default class VanillaTilt {
       "full-page-listening": false,
       "mouse-event-element": null,
       reset: true,
+      "reset-to-start": false,
       gyroscope: true,
       gyroscopeMinAngleX: -45,
       gyroscopeMaxAngleX: 45,


### PR DESCRIPTION
I wanted the tilt effect on `mouse leave` instead of going to `0,0` position for it to "go back to start" as it was first rendered.

In order to do it nicely, I did a little bit of refactoring.

In short, changes:
1. Merged `reset()` and `updateInitialPosition()` functions (later one takes precedence in whole logic) - Previously it was two logics where one is a hardcoded "always go to centre" and the other is a special case only used once in a lifetime of the class. Now it becomes one universal call where it "goes to home" whatever it might be, **with a default being `0,0`.**
2. Introduced new optional setting `reset-to-start` / `resetToStart` - default `false` makes it behave exactly as before.
3. Moved down `resetGlare()` (no effect to code execution)

Did a bunch of manual testing looking for regression with different settings, expecting to be it fully backwards compatible and only difference when both `startX`/`startY` and `resetToStart` feature enabled:

* `before` - behaves exactly as before
* `after` - new behaviour
* including there notable settings between the tilts

![chrome_XhqsqaOD5V](https://user-images.githubusercontent.com/6931156/206706497-4a80f830-0b76-4b3c-a74d-ee0499569377.gif)

And here same cases but now listening to the full page

![chrome_UxWblPjxCk](https://user-images.githubusercontent.com/6931156/206707232-becf4f25-ff84-40f2-9472-89330ebed726.gif)

